### PR TITLE
feat(ingress): add argocd.pdlab.dev + blog.pdlab.dev (blog-dev only)

### DIFF
--- a/kubernetes/base/argocd/ingress.yaml
+++ b/kubernetes/base/argocd/ingress.yaml
@@ -18,3 +18,14 @@ spec:
               number: 80
         path: /
         pathType: Prefix
+  # pdlab.dev mirror (dual-domain soak — remove argocd.toastedbytes.com block after cutover)
+  - host: argocd.pdlab.dev
+    http:
+      paths:
+      - backend:
+          service:
+            name: argocd-server
+            port:
+              number: 80
+        path: /
+        pathType: Prefix

--- a/kubernetes/overlays/dev/blog-agent-configmap-patch.yaml
+++ b/kubernetes/overlays/dev/blog-agent-configmap-patch.yaml
@@ -3,8 +3,8 @@ kind: ConfigMap
 metadata:
   name: blog-agent-config
 data:
-  BLOG_URL: "https://dev.petedillo.com"
-  CORS_ORIGINS: "https://dev.petedillo.com,http://localhost:5173"
+  BLOG_URL: "https://blog.pdlab.dev"
+  CORS_ORIGINS: "https://dev.petedillo.com,https://blog.pdlab.dev,http://localhost:5173"
   MC_BACKEND_URL: "http://mission-control-backend.mission-control.svc.cluster.local:3000"
   MINIO_ENDPOINT: "http://192.168.50.115:9000"
   MINIO_BUCKET: "blog-images"

--- a/kubernetes/overlays/dev/blog-api-ingress.yaml
+++ b/kubernetes/overlays/dev/blog-api-ingress.yaml
@@ -15,3 +15,14 @@ spec:
             name: blog-api
             port:
               number: 8080
+  # Public access via Cloudflare Tunnel — UI on blog.pdlab.dev calls /api/v1 on the same host
+  - host: blog.pdlab.dev
+    http:
+      paths:
+      - path: /api/v1
+        pathType: Prefix
+        backend:
+          service:
+            name: blog-api
+            port:
+              number: 8080

--- a/kubernetes/overlays/dev/blog-ui-ingress.yaml
+++ b/kubernetes/overlays/dev/blog-ui-ingress.yaml
@@ -15,3 +15,14 @@ spec:
             name: blog-ui
             port:
               number: 80
+  # Public access via Cloudflare Tunnel (replaces the retired blog-prod / blog.petedillo.com ingress)
+  - host: blog.pdlab.dev
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: blog-ui
+            port:
+              number: 80


### PR DESCRIPTION
## Summary
- `argocd.pdlab.dev` host rule added to argocd ingress
- `blog.pdlab.dev` host rule added to blog-dev's blog-ui + blog-api ingresses (decision: keep only blog-dev going forward; legacy blog-prod retired in soak)
- Blog-agent: `BLOG_URL` switched to `https://blog.pdlab.dev` for canonical link generation; CORS extended to allow both hosts

Part of the dual-domain soak for the toastedbytes -> pdlab.dev migration.

## Test plan
- [x] After merge, ArgoCD syncs `blog-dev` and `argocd` Applications
- [ ] `https://blog.pdlab.dev` returns 200 (UI) and `/api/v1/...` returns 200 (API)
- [ ] `https://argocd.pdlab.dev` returns the ArgoCD login page

🤖 Generated with [Claude Code](https://claude.com/claude-code)