### PR TITLE
chore: drop toastedbytes + dev.petedillo from blog ingresses

### DIFF
--- a/kubernetes/base/argocd/ingress.yaml
+++ b/kubernetes/base/argocd/ingress.yaml
@@ -8,17 +8,6 @@ metadata:
 spec:
   ingressClassName: public
   rules:
-  - host: argocd.toastedbytes.com
-    http:
-      paths:
-      - backend:
-          service:
-            name: argocd-server
-            port:
-              number: 80
-        path: /
-        pathType: Prefix
-  # pdlab.dev mirror (dual-domain soak — remove argocd.toastedbytes.com block after cutover)
   - host: argocd.pdlab.dev
     http:
       paths:

--- a/kubernetes/overlays/dev/blog-api-ingress.yaml
+++ b/kubernetes/overlays/dev/blog-api-ingress.yaml
@@ -5,17 +5,6 @@ metadata:
 spec:
   ingressClassName: public
   rules:
-  - host: dev.petedillo.com
-    http:
-      paths:
-      - path: /api/v1
-        pathType: Prefix
-        backend:
-          service:
-            name: blog-api
-            port:
-              number: 8080
-  # Public access via Cloudflare Tunnel — UI on blog.pdlab.dev calls /api/v1 on the same host
   - host: blog.pdlab.dev
     http:
       paths:

--- a/kubernetes/overlays/dev/blog-ui-ingress.yaml
+++ b/kubernetes/overlays/dev/blog-ui-ingress.yaml
@@ -5,17 +5,6 @@ metadata:
 spec:
   ingressClassName: public
   rules:
-  - host: dev.petedillo.com
-    http:
-      paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            name: blog-ui
-            port:
-              number: 80
-  # Public access via Cloudflare Tunnel (replaces the retired blog-prod / blog.petedillo.com ingress)
   - host: blog.pdlab.dev
     http:
       paths:


### PR DESCRIPTION
Phase H of pdlab.dev migration. 🤖 Generated with [Claude Code](https://claude.com/claude-code)